### PR TITLE
Attempt to fix brittle tests under chrome 132

### DIFF
--- a/gemfiles/Gemfile.rails61
+++ b/gemfiles/Gemfile.rails61
@@ -7,3 +7,6 @@ gem 'rails', '~> 6.1.0'
 # Rails 6.1 does not support sqlite3 2.x; it specifies gem "sqlite3", "~> 1.4"
 # in lib/active_record/connection_adapters/sqlite3_adapter.rb
 gem 'sqlite3', '~> 1.7'
+
+# Latest concurrent-ruby breaks Rails < 7.1. See https://github.com/rails/rails/issues/54260
+gem 'concurrent-ruby', '1.3.4'

--- a/gemfiles/Gemfile.rails70
+++ b/gemfiles/Gemfile.rails70
@@ -7,3 +7,6 @@ gem 'rails', '~> 7.0.0'
 # Rails 7.0 does not support sqlite3 2.x; it specifies gem "sqlite3", "~> 1.4"
 # in lib/active_record/connection_adapters/sqlite3_adapter.rb
 gem 'sqlite3', '~> 1.7'
+
+# Latest concurrent-ruby breaks Rails < 7.1. See https://github.com/rails/rails/issues/54260
+gem 'concurrent-ruby', '1.3.4'

--- a/ndr_error.gemspec
+++ b/ndr_error.gemspec
@@ -3,7 +3,9 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 # Maintain your gem's version:
 require 'ndr_error/version'
 
-# Describe your gem and declare its dependencies:
+# We list development dependencies for all Rails versions here.
+# Rails version-specific dependencies can go in the relevant Gemfile.
+# rubocop:disable Gemspec/DevelopmentDependencies
 Gem::Specification.new do |s|
   s.name        = 'ndr_error'
   s.version     = NdrError::VERSION
@@ -50,3 +52,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'ndr_dev_support', '>= 5.10'
   s.add_development_dependency 'simplecov'
 end
+# rubocop:enable Gemspec/DevelopmentDependencies

--- a/ndr_error.gemspec
+++ b/ndr_error.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   # Workaround build issue on GitHub Actions with ruby <= 3.1 when installing sass-embedded
   # gem version 1.81.0: NoMethodError: undefined method `parse' for #<Psych::Parser...>
   # https://bugs.ruby-lang.org/issues/19371
-  spec.add_development_dependency 'psych', '< 5'
+  s.add_development_dependency 'psych', '< 5'
 
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'test-unit', '~> 3.0'

--- a/ndr_error.gemspec
+++ b/ndr_error.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0'
 
   s.add_dependency 'rails', '>= 6.1', '< 7.3'
+  # See https://github.com/rails/rails/issues/54260.
+  s.add_dependency 'concurrent-ruby', '1.3.4'
 
   # Support rails 6.1 with Ruby 3.1
   s.add_dependency 'net-imap'

--- a/ndr_error.gemspec
+++ b/ndr_error.gemspec
@@ -38,6 +38,11 @@ Gem::Specification.new do |s|
   # cf. gemfiles/Gemfile.rails70
   s.add_development_dependency 'sqlite3'
 
+  # Workaround build issue on GitHub Actions with ruby <= 3.1 when installing sass-embedded
+  # gem version 1.81.0: NoMethodError: undefined method `parse' for #<Psych::Parser...>
+  # https://bugs.ruby-lang.org/issues/19371
+  spec.add_development_dependency 'psych', '< 5'
+
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'test-unit', '~> 3.0'
 

--- a/ndr_error.gemspec
+++ b/ndr_error.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0'
 
   s.add_dependency 'rails', '>= 6.1', '< 7.3'
-  # See https://github.com/rails/rails/issues/54260.
-  s.add_dependency 'concurrent-ruby', '1.3.4'
 
   # Support rails 6.1 with Ruby 3.1
   s.add_dependency 'net-imap'
@@ -30,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'will_paginate'
 
-  s.add_dependency 'ndr_ui'
+  s.add_dependency 'ndr_ui', '>= 5.0'
 
   s.add_development_dependency 'pry'
   s.add_development_dependency 'puma'

--- a/ndr_error.gemspec
+++ b/ndr_error.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'will_paginate'
 
-  s.add_dependency 'ndr_ui', '>= 5.0'
+  s.add_dependency 'ndr_ui', '< 5.0'
 
   s.add_development_dependency 'pry'
   s.add_development_dependency 'puma'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,6 +33,23 @@ ActionDispatch::IntegrationTest.class_eval do
   # Instead, insert fixtures afresh between each test:
   setup    { DatabaseCleaner.start }
   teardown { DatabaseCleaner.clean }
+
+  # assert_current_path is brittle with Chrome 132 on capybara 3.40.0
+  # Retry up to 3 times on error
+  def assert_current_path(path, **options, &optional_filter_block)
+    failures = 0
+    begin
+      super
+    rescue Selenium::WebDriver::Error::WebDriverError => e
+      failures += 1
+      if e.message.start_with?('aborted by navigation: loader has changed ' \
+                               "while resolving nodes\n") && failures <= 3
+        # puts "Retrying after failure #{failures}: #{e.class} #{e.message}"
+        retry
+      end
+      raise
+    end
+  end
 end
 
 # Include all capybara + poltergeist config


### PR DESCRIPTION
This PR attempts to get `ndr_error` tests running again (pre-bootstrap 5 upgrades to `ndr_ui`) and identify the cause of the recent brittle tests like the following (https://github.com/NHSDigital/ndr_error/actions/runs/12950940910/job/36217578005?pr=32 on PR https://github.com/NHSDigital/ndr_error/pull/32):
```
Error:
ErrorViewingTest#test_should_be_able_to_purge_logs:
Selenium::WebDriver::Error::WebDriverError: aborted by navigation: loader has changed while resolving nodes
  (Session info: chrome=132.0.6834.83)
    selenium-webdriver (4.28.0) lib/selenium/webdriver/remote/response.rb:63:in `add_cause'
    selenium-webdriver (4.28.0) lib/selenium/webdriver/remote/response.rb:41:in `error'
    selenium-webdriver (4.28.0) lib/selenium/webdriver/remote/response.rb:52:in `assert_ok'
    selenium-webdriver (4.28.0) lib/selenium/webdriver/remote/response.rb:34:in `initialize'
    selenium-webdriver (4.28.0) lib/selenium/webdriver/remote/http/common.rb:103:in `new'
    selenium-webdriver (4.28.0) lib/selenium/webdriver/remote/http/common.rb:103:in `create_response'
    selenium-webdriver (4.28.0) lib/selenium/webdriver/remote/http/default.rb:103:in `request'
    selenium-webdriver (4.28.0) lib/selenium/webdriver/remote/http/common.rb:68:in `call'
    selenium-webdriver (4.28.0) lib/selenium/webdriver/remote/bridge.rb:685:in `execute'
    selenium-webdriver (4.28.0) lib/selenium/webdriver/remote/bridge.rb:167:in `url'
    selenium-webdriver (4.28.0) lib/selenium/webdriver/common/driver.rb:160:in `current_url'
    capybara (3.40.0) lib/capybara/selenium/driver.rb:121:in `current_url'
    capybara (3.40.0) lib/capybara/session.rb:232:in `current_url'
    capybara (3.40.0) lib/capybara/queries/current_path_query.rb:21:in `resolves_for?'
    capybara (3.40.0) lib/capybara/session/matchers.rb:24:in `block in assert_current_path'
    capybara (3.40.0) lib/capybara/session/matchers.rb:75:in `block in _verify_current_path'
    capybara (3.40.0) lib/capybara/node/base.rb:84:in `synchronize'
    capybara (3.40.0) lib/capybara/session/matchers.rb:74:in `_verify_current_path'
    capybara (3.40.0) lib/capybara/session/matchers.rb:23:in `assert_current_path'
    capybara (3.40.0) lib/capybara/dsl.rb:52:in `call'
    capybara (3.40.0) lib/capybara/dsl.rb:52:in `assert_current_path'
    test/integration/error_viewing_test.rb:121:in `block in <class:ErrorViewingTest>'
    minitest (5.25.4) lib/minitest/test.rb:94:in `block (2 levels) in run'
    minitest (5.25.4) lib/minitest/test.rb:190:in `capture_exceptions'
    minitest (5.25.4) lib/minitest/test.rb:89:in `block in run'
    minitest (5.25.4) lib/minitest.rb:368:in `time_it'
    minitest (5.25.4) lib/minitest/test.rb:88:in `run'
    ndr_dev_support (7.3.1) lib/ndr_dev_support/integration_testing/flakey_tests.rb:32:in `run'
    minitest (5.25.4) lib/minitest.rb:1208:in `run_one_method'
    minitest (5.25.4) lib/minitest.rb:447:in `run_one_method'
    minitest (5.25.4) lib/minitest.rb:434:in `block (2 levels) in run'
    minitest (5.25.4) lib/minitest.rb:430:in `each'
    minitest (5.25.4) lib/minitest.rb:430:in `block in run'
    minitest (5.25.4) lib/minitest.rb:472:in `on_signal'
    minitest (5.25.4) lib/minitest.rb:459:in `with_info_handler'
    minitest (5.25.4) lib/minitest.rb:429:in `run'
    railties (7.0.8.7) lib/rails/test_unit/line_filtering.rb:10:in `run'
    minitest (5.25.4) lib/minitest.rb:332:in `block in __run'
    minitest (5.25.4) lib/minitest.rb:332:in `map'
    minitest (5.25.4) lib/minitest.rb:332:in `__run'
    minitest (5.25.4) lib/minitest.rb:288:in `run'
    minitest (5.25.4) lib/minitest.rb:86:in `block in autorun'

rails test test/integration/error_viewing_test.rb:110
```
[Edit: copied from comment below]
All our failures were on calls to `assert_current_path,` and I've written an override method to retry this up to 3 times. I've added the following to `test/test_helper.rb`:
```ruby
ActionDispatch::IntegrationTest.class_eval do
  # assert_current_path is brittle with Chrome 132 on capybara 3.40.0
  # Retry up to 3 times on error
  def assert_current_path(path, **options, &optional_filter_block)
    failures = 0
    begin
      super
    rescue Selenium::WebDriver::Error::WebDriverError => e
      failures += 1
      if e.message.start_with?('aborted by navigation: loader has changed ' \
                               "while resolving nodes\n") && failures <= 3
        # puts "Retrying after failure #{failures}: #{e.class} #{e.message}"
        retry
      end
      raise
    end
  end
end
```