### PR TITLE
tag version v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## [Unreleased]
++* no unreleased changes
+
+## 2.4.0 / 2025-01-31
 ### Changed
-* new views with bootstrap 5 styles
-* switch to bootstrap-icons as glyphicon no longer available in bootstrap 5
+* New views with bootstrap 5 styles
+* Switch to bootstrap-icons as glyphicon no longer available in bootstrap 5
 
 ## 2.3.2 / 2024-11-21
 ### Fixed

--- a/lib/ndr_error/version.rb
+++ b/lib/ndr_error/version.rb
@@ -2,5 +2,5 @@
 
 # Contains the version of NdrError. Sourced by the gemspec.
 module NdrError
-  VERSION = '2.3.2'
+  VERSION = '2.4.0'
 end


### PR DESCRIPTION
This is a minor release: it supports the latest `ndr_ui` gem version, which switches from bootstrap 3 to bootstrap 5, but has no other functional changes.